### PR TITLE
Bug fix rm indices

### DIFF
--- a/R/fhircrack.R
+++ b/R/fhircrack.R
@@ -770,13 +770,15 @@ fhir_melt <-
 	function(indexed_data_frame,
 			 columns,
 			 brackets = c("<", ">"),
-			 sep = " -+- ",
+			 sep = " ",
 			 id_name = "resource_identifier",
 			 all_columns = FALSE) {
 
 		if (!all(columns %in% names(indexed_data_frame))) {
 			stop("Not all column names you gave match with the column names in the data frame.")
 		}
+
+		brackets <- fix_brackets(brackets)
 
 		is_DT <- data.table::is.data.table(indexed_data_frame)
 
@@ -811,12 +813,8 @@ fhir_melt <-
 		if (!is.null(d) && 0 < nrow(d)) {
 			data.table::setorder(d, id_name)
 
-			if(!is_DT){
-				setDF(d)
-				return(d)
-			}else{
-				return(d)
-			}
+			if(!is_DT){setDF(d)}
+			return(d)
 
 		}
 	}
@@ -883,14 +881,13 @@ fhir_rm_indices <-
 
 		if(!is_DT){data.table::setDT(indexed_data_frame)}
 
-		if(length(brackets) < 2 ) brackets <- c(brackets[1], brackets[1])
+		brackets <- fix_brackets(brackets)
 
 		brackets.escaped <- esc(brackets)
 
 		pattern.ids <- paste0(brackets.escaped[1], "([0-9]+\\.*)+", brackets.escaped[2])
 
 		result <- data.table::data.table(gsub( pattern.ids, "", as.matrix(indexed_data_frame[,columns, with=F])))
-		#result <- data.table::data.table(gsub( pattern.ids, "", as.matrix(indexed_data_frame[,columns, with=F])))
 
 		indexed_data_frame[ , columns] <- result
 

--- a/R/fhircrack.R
+++ b/R/fhircrack.R
@@ -883,21 +883,17 @@ fhir_rm_indices <-
 
 		if(!is_DT){data.table::setDT(indexed_data_frame)}
 
-
 		brackets.escaped <- esc(brackets)
 
 		pattern.ids <- paste0(brackets.escaped[1], "([0-9]*\\.*)+", brackets.escaped[2])
 
-
 		result <- data.table::data.table(gsub( pattern.ids, "", as.matrix(indexed_data_frame[,columns, with=F] )))
 
-		if(!is_DT){
-			data.table::setDF(result)
-			return(result)
-		}else{
-			return(result)
-		}
+		indexed_data_frame[ , columns] <- result
 
+		if(!is_DT) data.table::setDF(indexed_data_frame)
+
+		indexed_data_frame
 }
 
 

--- a/R/fhircrack.R
+++ b/R/fhircrack.R
@@ -883,11 +883,14 @@ fhir_rm_indices <-
 
 		if(!is_DT){data.table::setDT(indexed_data_frame)}
 
+		if(length(brackets) < 2 ) brackets <- c(brackets[1], brackets[1])
+
 		brackets.escaped <- esc(brackets)
 
-		pattern.ids <- paste0(brackets.escaped[1], "([0-9]*\\.*)+", brackets.escaped[2])
+		pattern.ids <- paste0(brackets.escaped[1], "([0-9]+\\.*)+", brackets.escaped[2])
 
-		result <- data.table::data.table(gsub( pattern.ids, "", as.matrix(indexed_data_frame[,columns, with=F] )))
+		result <- data.table::data.table(gsub( pattern.ids, "", as.matrix(indexed_data_frame[,columns, with=F])))
+		#result <- data.table::data.table(gsub( pattern.ids, "", as.matrix(indexed_data_frame[,columns, with=F])))
 
 		indexed_data_frame[ , columns] <- result
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -783,7 +783,7 @@ melt_row <-
 	function(row,
 			 columns,
 			 brackets = c("<", ">"),
-			 sep = " -+- ",
+			 sep = " ",
 			 all_columns = FALSE) {
 
 		row <- as.data.frame(row)

--- a/man/fhir_melt.Rd
+++ b/man/fhir_melt.Rd
@@ -8,7 +8,7 @@ fhir_melt(
   indexed_data_frame,
   columns,
   brackets = c("<", ">"),
-  sep = " -+- ",
+  sep = " ",
   id_name = "resource_identifier",
   all_columns = FALSE
 )


### PR DESCRIPTION
Es waren sogar 2 Bugs.
1. kamen nur die columns zurueck, die man der Indizes entledigen wollte.
2. bei brackets = "|" hat er keinen 2er vektor vor der verwendung daraus gemacht ...  c("|","|")