### PR TITLE
parallelization of cracking bundles, only for macos and linux

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ Imports:
     dplyr,
     plyr,
     data.table,
-    methods
+    methods,
+    parallel
 Suggests: 
     knitr,
     rmarkdown


### PR DESCRIPTION
Simple parallelization of cracking bundles.
uses mclapply of the parallel package. This works by forking, so threads use shared memory of the parent process which is compatible with the external pointers used by xml2 functions.
Windows can not do that, so only for Linux and Macos.