### PR TITLE
150 fhir crack crashes with empty bundles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: fhircrackr
 Type: Package
 Title: Handling HL7 FHIR® Resources in R
-Version: 2.2.0.9002
-Date: 2025-01-24
+Version: 2.2.0.9003
+Date: 2025-03-05
 Authors@R: c(
     person( given = "Thomas", 
             family = "Peschel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 - Errors when removing tags in `fhir_search()` (e.g. with `rm_tag = "div"`) now get caught and converted to a warning.
+- `fhir_crack() doesn't crash anymore when some of the bundles don't contain the searched resources.
 
 ## New functionalities
 

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -638,7 +638,6 @@ crack_wide_given_columns <- function(bundles, table_description, ncores = 1) {
 					d <- dcast(d, entry ~ column) # cast columns by bundle and entry
 					data.table::setcolorder(x = d, neworder = cols)
 				}
-				d
 			},
 			mc.cores = ncores
 		),

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -717,7 +717,6 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 							d <- (d[, stringr::str_c(value, collapse = table_description@sep), by=c('entry', 'column')] |> dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
 						}
 					}
-					d
 				},
 				mc.cores = ncores
 			),


### PR DESCRIPTION
In the core cracking functions, an empty bundle (or bundle not containing the resource being cracked) must return nothing in order to create the correct data.table in the `data.table::rbindlist()` statement. Until now it had returned a data.table containing an xml nodeset.