### PR TITLE
[codex] Optimize fhir_crack given-column extraction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ BugReports: https://github.com/POLAR-fhiR/fhircrackr/issues
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
 Imports: 
     xml2,
     stringr,
@@ -71,3 +70,4 @@ Collate:
     'miscellaneous.R'
     'multiple_entries.R'
     'sample_resources.R'
+Config/roxygen2/version: 8.0.0

--- a/R/download_resources.R
+++ b/R/download_resources.R
@@ -999,7 +999,7 @@ fhir_authenticate <- function(
 #' Download single FHIR bundle
 #' @description Download a single FHIR bundle via FHIR search request and return it as a xml object.
 #'
-#' @param request An object of class [fhir_search_url-class] or character vector of length one containing the full FHIR search request.
+#' @param request An object of class [fhir_url-class] or character vector of length one containing the full FHIR search request.
 #' @param username A character vector of length one containing the username for basic authentication. Defaults to NULL, meaning no authentication.
 #' @param password A character vector of length one containing the password for basic authentication. Defaults to NULL, meaning no authentication.
 #' @param token The token for token based auth, either a string or a httr token object

--- a/R/fhir_tree.R
+++ b/R/fhir_tree.R
@@ -115,12 +115,12 @@ fhir_tree <- function(table,
 
 #' Create text version of tree
 #'
-#' @param tree A tree as produced by [fhir_tree.new()]
+#' @param tree A tree as produced by fhir_tree.new()
 #' @param tabs A string that is put at the beginning of each line
 #' @param tab The string used for indentation of each line
-#' @param keep_attr A logical of length one indication whether attributes should be keeped in names. Defaults to `FALSE`.
-#' @param keep_ids A logical of length one indication whether attributes should be keeped in names. Defaults to `TRUE`.
-#' @param skip_one A logical of length one indication whether attributes should be keeped in names. Defaults to `TRUE`. Has no effect if `keep_ids` is `FALSE`.
+#' @param keep_attr A logical of length one indication whether attributes should be kept in names. Defaults to `FALSE`.
+#' @param keep_ids A logical of length one indication whether attributes should be kept in names. Defaults to `TRUE`.
+#' @param skip_one A logical of length one indication whether attributes should be kept in names. Defaults to `TRUE`. Has no effect if `keep_ids` is `FALSE`.
 #'
 #' @noRd
 #' @examples
@@ -187,11 +187,11 @@ fhir_tree.as_text <- function(tree,
 
 #' Create string for printing of tree
 #'
-#' @param tree A tree as produced by [fhir_tree.new()]
+#' @param tree A tree as produced by fhir_tree.new()
 #' @param prompt A string that is put between each element and its value. Defaults to a semicolon.
-#' @param keep_attr A logical of length one indication whether attributes should be keeped in names. Defaults to `FALSE`.
-#' @param keep_ids A logical of length one indication whether attributes should be keeped in names. Defaults to `TRUE`.
-#' @param skip_one A logical of length one indication whether attributes should be keeped in names. Defaults to `TRUE`. Has no effect if `keep_ids` is `FALSE`.
+#' @param keep_attr A logical of length one indication whether attributes should be kept in names. Defaults to `FALSE`.
+#' @param keep_ids A logical of length one indication whether attributes should be kept in names. Defaults to `TRUE`.
+#' @param skip_one A logical of length one indication whether attributes should be kept in names. Defaults to `TRUE`. Has no effect if `keep_ids` is `FALSE`.
 #'
 #' @noRd
 #' @examples
@@ -301,7 +301,7 @@ fhir_tree.as_string <-
 
 #' Create xml version of tree
 #'
-#' @param tree A tree as produced by [fhir_tree.new()]
+#' @param tree A tree as produced by fhir_tree.new()
 #' @param escaped Escape special xml characters? Defaults to `TRUE`
 #' @param tabs A string that is put at the beginning of each line
 #' @param tab The string used for indentation of each line
@@ -484,68 +484,11 @@ fhir_tree.new <- function(table, brackets, root) {
 	}
 	tree
 }
-#'
-#' #' Apply Functions on a Tree
-#' #'
-#' #' @param tree A tree as build by fhir_tree.new() from a wide cracked table.
-#' #' @param fun.start A Function called before going deeper into the tree.
-#' #' @param fun.finish A Function called after going deeper into the tree.
-#' #'
-#' #' @return A Tree.
-#' #' @export
-#' #'
-#' #' @examples
-#' #' #unserialize example
-#' #' bundles <- fhir_unserialize(bundles = example_bundles1)
-#' #'
-#' #' #crack fhir resources
-#' #' table_desc <- fhir_table_description(
-#' #'     resource = "Patient",
-#' #'     brackets = c("[", "]"),
-#' #'     sep      = " "
-#' #' )
-#' #' df <- fhir_crack(bundles = bundles, design = table_desc)
-#' #'
-#' #' #cast silently using bracktets and separator definitions from table_desc
-#' #' cast_df <- fhir_cast(df, brackets = table_desc@brackets, sep = table_desc@sep, verbose = 0)
-#' #'
-#' #' #build tree
-#' #' tree <- fhir_tree.new(cast_df, brackets = table_desc@brackets, root = "Patient")
-#' #' tree_applied <- fhir_tree.apply(tree, fhir_tree.fun.rm_ids)
-#' #' tree_faster <- fhir_tree.rm_ids(tree)
-#' #' cat(fhir_tree.as_text(tree_applied))
-#' #' cat(fhir_tree.as_text(tree_faster))
-#' fhir_tree.apply <- function(tree, fun.start = NULL, fun.finish = NULL) {
-#' 	if(!is.null(fun.start)) tree <- fun.start(node = tree)
-#' 	for(n in seq_along(tree)) {
-#' 		tree[[n]] <- fhir_tree.apply(tree = tree[[n]], fun.start = fun.start, fun.finish = fun.finish)
-#' 	}
-#' 	if(!is.null(fun.finish)) tree <- fun.finish(node = tree)
-#' 	tree
-#' }
-#'
-#' ###
-#' # Closure Functions for fhir_tree.apply
-#' ###
-#' #' more docu needed
-#' #' @param node the node
-#' #' @noRd
-#' fhir_tree.fun.rm_ids <- function(node) {
-#' 	names(node) <- gsub('[0-9]+$', '', names(node))
-#' 	node
-#' }
-#'
-#' #' more docu needed
-#' #' @param node the node
-#' #' @noRd
-#' fhir_tree.fun.skip_one <- function(node) {
-#' 	names(node) <- gsub('([^0-9]+)(1$)', '\\1',  names(node))
-#' 	node
-#' }
+
 
 #' Remove ids from tree
 #' Removes the ids leftover from the casted table
-#' @param tree A tree as produced by [fhir_tree.new()]
+#' @param tree A tree as produced by fhir_tree.new()
 #'
 #' @examples
 #' #unserialize example

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -590,10 +590,6 @@ crack_given_columns_nodes_to_long <- function(nodes, columns, table_description,
 		columns <- paste0(columns, "@", substring(paths, attr_start + 2L))
 	}
 
-	resource_start <- entry_close + nchar("]/resource/")
-	slash_after_resource <- regexpr("/", substring(paths, resource_start), fixed = TRUE)
-	spath_start <- resource_start + slash_after_resource
-	spath <- substr(paths, spath_start, attr_start - 1L)
 	d <- data.table(
 		entry  = as.integer(substr(paths, nchar("/Bundle/entry[") + 1L, entry_close - 1L)),
 		column = columns,
@@ -601,6 +597,10 @@ crack_given_columns_nodes_to_long <- function(nodes, columns, table_description,
 	)
 
 	if(use_indices) {
+		resource_start <- entry_close + nchar("]/resource/")
+		slash_after_resource <- regexpr("/", substring(paths, resource_start), fixed = TRUE)
+		spath_start <- resource_start + slash_after_resource
+		spath <- substr(paths, spath_start, attr_start - 1L)
 		unique_spath <- unique(spath)
 		indexed_spath <- gsub(
 			pattern = "(^|/)([^/[]+)(?=/|$)",

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -787,60 +787,69 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 		paste0('./entry/resource/', table_description@resource, '/', table_description@cols, '/@*'),
 		names(table_description@cols)
 	)
-	result <- unique(
-		data.table::rbindlist(
-			parallel::mclapply(
-				seq_along(bundles),
-				function(bundle_id) {# bundle_id <- 1
-					bundle_ns <- xml2::xml_ns(bundles[[bundle_id]])
-					colwise_list <- lapply(
-						xpaths,
-						function(xpath) {# xpath <- table_description@cols[[1]]
-							xml2::xml_find_all(
-								bundles[[bundle_id]],
-								xpath,
-								ns = bundle_ns
-							)
-						}
-					)
-					nodelist <-	unlist(
-						colwise_list,
-						recursive = FALSE,
-						use.names = FALSE
-					)
-
-					if(0 < length(nodelist)){
-						d <- crack_given_columns_nodes_to_long(
-							nodes             = xml_nodeset(nodelist, deduplicate = FALSE),
-							columns           = rep(names(colwise_list), lengths(colwise_list)),
-							table_description = table_description,
-							use_indices       = use_indices
+	result <- data.table::rbindlist(
+		parallel::mclapply(
+			seq_along(bundles),
+			function(bundle_id) {# bundle_id <- 1
+				bundle_ns <- xml2::xml_ns(bundles[[bundle_id]])
+				colwise_list <- lapply(
+					xpaths,
+					function(xpath) {# xpath <- table_description@cols[[1]]
+						xml2::xml_find_all(
+							bundles[[bundle_id]],
+							xpath,
+							ns = bundle_ns
 						)
-						if(use_indices) {
-							d <- cast_compact_given_columns(
-								d                 = d,
-								table_description = table_description,
-								use_indices       = TRUE,
-								bra               = bra,
-								ket               = ket
-							)
-						} else {
-							d <- cast_compact_given_columns(
-								d                 = d,
-								table_description = table_description,
-								use_indices       = FALSE,
-								bra               = bra,
-								ket               = ket
-							)
-						}
 					}
-				},
-				mc.cores = ncores
-			),
-			use.names = TRUE,
-			fill = TRUE
-		)
+				)
+				nodelist <-	unlist(
+					colwise_list,
+					recursive = FALSE,
+					use.names = FALSE
+				)
+
+				if(0 < length(nodelist)){
+					d <- crack_given_columns_nodes_to_long(
+						nodes             = xml_nodeset(nodelist, deduplicate = FALSE),
+						columns           = rep(names(colwise_list), lengths(colwise_list)),
+						table_description = table_description,
+						use_indices       = use_indices
+					)
+					if(use_indices) {
+						d <- cast_compact_given_columns(
+							d                 = d,
+							table_description = table_description,
+							use_indices       = TRUE,
+							bra               = bra,
+							ket               = ket
+						)
+					} else {
+						d <- cast_compact_given_columns(
+							d                 = d,
+							table_description = table_description,
+							use_indices       = FALSE,
+							bra               = bra,
+							ket               = ket
+						)
+					}
+				}
+			},
+			mc.cores = ncores
+		),
+		use.names = TRUE,
+		fill = TRUE
 	)
+	resource_id_col <- names(table_description@cols)[table_description@cols == "id"]
+	if(
+		nrow(result) != 0 &&
+		(
+			length(resource_id_col) != 1 ||
+			!resource_id_col %in% names(result) ||
+			anyDuplicated(result[[resource_id_col]]) != 0
+		)
+	) {
+		result <- unique(result)
+	}
 	if(rm_dummy){result[,grep("^dummy", names(result)):=NULL]}
 	result
 }

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -815,23 +815,13 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 						table_description = table_description,
 						use_indices       = use_indices
 					)
-					if(use_indices) {
-						d <- cast_compact_given_columns(
-							d                 = d,
-							table_description = table_description,
-							use_indices       = TRUE,
-							bra               = bra,
-							ket               = ket
-						)
-					} else {
-						d <- cast_compact_given_columns(
-							d                 = d,
-							table_description = table_description,
-							use_indices       = FALSE,
-							bra               = bra,
-							ket               = ket
-						)
-					}
+					d <- cast_compact_given_columns(
+						d                 = d,
+						table_description = table_description,
+						use_indices       = use_indices,
+						bra               = bra,
+						ket               = ket
+					)
 				}
 			},
 			mc.cores = ncores

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -574,6 +574,45 @@ crack_compact_all_columns <- function(bundles, table_description, ncores = 1) {
 	)
 }
 
+#' Convert extracted XML attribute nodes into a long table
+#' @param nodes XML attribute nodes extracted from one bundle
+#' @param columns Column names matching the extracted nodes
+#' @param table_description A fhir_table_description
+#' @param use_indices Whether FHIR path indices should be extracted
+#' @noRd
+crack_given_columns_nodes_to_long <- function(nodes, columns, table_description, use_indices) {
+	paths <- xml2::xml_path(nodes)
+	values <- xml2::xml_text(nodes)
+	entry_close <- regexpr("]", paths, fixed = TRUE)
+	attr_start <- regexpr("/@", paths, fixed = TRUE)
+
+	if(table_description@keep_attr) {
+		columns <- paste0(columns, "@", substring(paths, attr_start + 2L))
+	}
+
+	resource_start <- entry_close + nchar("]/resource/")
+	slash_after_resource <- regexpr("/", substring(paths, resource_start), fixed = TRUE)
+	spath_start <- resource_start + slash_after_resource
+	spath <- substr(paths, spath_start, attr_start - 1L)
+	d <- data.table(
+		entry  = as.integer(substr(paths, nchar("/Bundle/entry[") + 1L, entry_close - 1L)),
+		column = columns,
+		value  = values
+	)
+
+	if(use_indices) {
+		indexed_spath <- gsub(
+			pattern = "(^|/)([^/[]+)(?=/|$)",
+			replacement = "\\11",
+			x = spath,
+			perl = TRUE
+		)
+		d[, id := gsub("(^\\.)|(\\.$)", "", gsub("[^0-9]+", ".", indexed_spath))]
+	}
+
+	d
+}
+
 #' Convert Bundles to a wide table when only some elements should be extracted
 #' @param bundles A fhir_bundle_list
 #' @param table_description A fhir_table_description with a non-empty cols element
@@ -595,17 +634,23 @@ crack_wide_given_columns <- function(bundles, table_description, ncores = 1) {
 		table_description@cols <- fhir_columns(c(c(dummy="id"), table_description@cols))
 		rm_dummy <- TRUE
 	}
+	xpaths <- stats::setNames(
+		paste0('./entry/resource/', table_description@resource, '/', table_description@cols, '/@*'),
+		names(table_description@cols)
+	)
 
 	result <- data.table::rbindlist(
 		parallel::mclapply(
 			seq_along(bundles),
 			function(bundle_id) {# bundle_id <- 1
+				bundle_ns <- xml2::xml_ns(bundles[[bundle_id]])
 				colwise_list <- lapply(
-					table_description@cols,
+					xpaths,
 					function(xpath) {# xpath <- table_description@cols[[1]]
 						xml2::xml_find_all(
 							bundles[[bundle_id]],
-							stringr::str_c('./entry/resource/', table_description@resource, '/', xpath, '/@*')
+							xpath,
+							ns = bundle_ns
 						)
 					}
 				)
@@ -615,25 +660,15 @@ crack_wide_given_columns <- function(bundles, table_description, ncores = 1) {
 					use.names = FALSE
 				)
 
-				d <- data.table(
-					node   = xml_nodeset(nodelist),
-					column = rep(names(colwise_list), lengths(colwise_list))
-				)
-				if(0 < nrow(d)){
-					d <- (d[, path     := xml2::xml_path(node) |> busg('/Bundle/', '') |> busg('([^]])/', '\\1[1]/')] # add missing indices
-						  [, value    := xml2::xml_text(node)] # get value
-						  [, attrib   := path |> busg('.*@', '')] # get attribute
-						  [, path     := path |> busg('@.*', '')] # remove attribute from path
-						  [, entry    := path |> busg('entry\\[([0-9]+)].*', '\\1') |> as.integer()] # enumerate entry
-						  [, spath    := path |> busg('^[^/]+/[^/]+/[^/]+/','')] # remove 'Bundle/entry/resource' from paths
-						  [, id       := spath |> busg('[^0-9]+', '.') |> busg('(^\\.)|(\\.$)', '')] # extract ids
-						  [, xpath    := spath |> busg('\\[[0-9]+]*/', '/') |> busg('\\/$', '')] # remove ids
-						  [, column   := stringr::str_c(bra, id, ket, column) |>
-						  		#busg('/', '.') |>
-						  		stringr::str_c(if(table_description@keep_attr) stringr::str_c('@', attrib) else '')
-						  ] # create column name
-						  [, -c('node', 'xpath', 'spath', 'attrib', 'id')] # remove unnecessary columns
+				if(0 < length(nodelist)){
+					d <- crack_given_columns_nodes_to_long(
+						nodes             = xml_nodeset(nodelist),
+						columns           = rep(names(colwise_list), lengths(colwise_list)),
+						table_description = table_description,
+						use_indices       = TRUE
 					)
+					d[, column := paste0(bra, id, ket, column)]
+					d[, id := NULL]
 					cols <- unique(d$column)
 					d <- dcast(d, entry ~ column) # cast columns by bundle and entry
 					data.table::setcolorder(x = d, neworder = cols)
@@ -671,17 +706,23 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 		ket <- table_description@brackets[[2]]
 		use_indices <- TRUE
 	}
+	xpaths <- stats::setNames(
+		paste0('./entry/resource/', table_description@resource, '/', table_description@cols, '/@*'),
+		names(table_description@cols)
+	)
 	result <- unique(
 		data.table::rbindlist(
 			parallel::mclapply(
 				seq_along(bundles),
 				function(bundle_id) {# bundle_id <- 1
+					bundle_ns <- xml2::xml_ns(bundles[[bundle_id]])
 					colwise_list <- lapply(
-						table_description@cols,
+						xpaths,
 						function(xpath) {# xpath <- table_description@cols[[1]]
 							xml2::xml_find_all(
 								bundles[[bundle_id]],
-								stringr::str_c('./entry/resource/', table_description@resource, '/', xpath, '/@*')
+								xpath,
+								ns = bundle_ns
 							)
 						}
 					)
@@ -691,29 +732,18 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 						use.names = FALSE
 					)
 
-					d <- data.table(
-						node   = xml_nodeset(nodelist),
-						column = rep(names(colwise_list), lengths(colwise_list))
-					)
-					if(0 < nrow(d)){
-						(d[, path     := xml2::xml_path(node) |> busg('/Bundle/', '')|> busg('([^]])/', '\\1[1]/')] # add missing indices
-						 [, value    := xml2::xml_text(node)] # get value
-						 [, attrib   := path |> busg('.*@', '')] # get attribute
-						 [, path     := path |> busg('@.*', '')] # remove attribute from path
-						 [, entry    := path |> busg('entry\\[([0-9]+)].*', '\\1') |> as.integer()] # enumerate entry
-						 [, spath    := path |> busg('^[^/]+/[^/]+/[^/]+/','')] # remove 'Bundle/entry/resource' from paths
-						 [, xpath    := spath |> busg('\\[[0-9]+]*/', '/') |> busg('\\/$', '')]
-						 [, column   := column |> stringr::str_c(if(table_description@keep_attr) stringr::str_c('@', attrib) else '')] #attach attribute to column name
-						 # [, column   := stringr::str_c(names(table_description@cols)[match(xpath, gsub("\\[.*\\]", "",table_description@cols))]) |>
-						 # 		busg('/', '.') |>
-						 # 		stringr::str_c(if(table_description@keep_attr) stringr::str_c('@', attrib) else '')
-						 # ] # create column name
+					if(0 < length(nodelist)){
+						d <- crack_given_columns_nodes_to_long(
+							nodes             = xml_nodeset(nodelist),
+							columns           = rep(names(colwise_list), lengths(colwise_list)),
+							table_description = table_description,
+							use_indices       = use_indices
 						)
 						if(use_indices) {
-							d <- (d[, id := spath |> busg('[^0-9]+', '.') |> busg('(^\\.)|(\\.$)', '')][, stringr::str_c(bra, id, ket, value, collapse = table_description@sep), by=c('entry', 'column')] |>
+							d <- (d[, paste0(bra, id, ket, value, collapse = table_description@sep), by=c('entry', 'column')] |>
 								  	dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
 						} else {
-							d <- (d[, stringr::str_c(value, collapse = table_description@sep), by=c('entry', 'column')] |> dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
+							d <- (d[, paste0(value, collapse = table_description@sep), by=c('entry', 'column')] |> dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
 						}
 					}
 				},
@@ -726,5 +756,3 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 	if(rm_dummy){result[,grep("^dummy", names(result)):=NULL]}
 	result
 }
-
-

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -623,24 +623,70 @@ crack_given_columns_nodes_to_long <- function(nodes, columns, table_description,
 #' @param ket Closing bracket for indices
 #' @noRd
 cast_compact_given_columns <- function(d, table_description, use_indices, bra, ket) {
+	entries <- sort(unique(d$entry))
+	cols <- sort(unique(d$column))
+	values <- matrix(NA_character_, nrow = length(entries), ncol = length(cols))
+
+	# Dense repeated columns are faster with data.table's grouped collapse.
+	if(nrow(d) / (length(entries) * length(table_description@cols)) > 2) {
+		if(use_indices) {
+			d <- d[
+				,
+				paste0(bra, id, ket, value, collapse = table_description@sep),
+				by = c('entry', 'column')
+			]
+		} else {
+			d <- d[
+				,
+				paste0(value, collapse = table_description@sep),
+				by = c('entry', 'column')
+			]
+		}
+		values[cbind(match(d$entry, entries), match(d$column, cols))] <- d$V1
+		return(data.table::setnames(data.table::as.data.table(values), cols))
+	}
+
+	data.table::setorder(d, entry, column)
+	group_start <- c(TRUE, d$entry[-1L] != d$entry[-nrow(d)] | d$column[-1L] != d$column[-nrow(d)])
+	group_start <- which(group_start)
+	group_end <- c(group_start[-1L] - 1L, nrow(d))
+	group_size <- group_end - group_start + 1L
+	singleton_group <- group_size == 1L
+
 	if(use_indices) {
-		d <- d[
-			,
-			paste0(bra, id, ket, value, collapse = table_description@sep),
-			by = c('entry', 'column')
-		]
+		group_values <- paste0(bra, d$id, ket, d$value)
 	} else {
-		d <- d[
+		group_values <- d$value
+	}
+
+	if(any(singleton_group)) {
+		singleton_start <- group_start[singleton_group]
+		values[
+			cbind(
+				match(d$entry[singleton_start], entries),
+				match(d$column[singleton_start], cols)
+			)
+		] <- group_values[singleton_start]
+	}
+
+	if(any(!singleton_group)) {
+		multi_rows <- rep(!singleton_group, group_size)
+		multi_values <- data.table(
+			entry = d$entry[multi_rows],
+			column = d$column[multi_rows],
+			value = group_values[multi_rows]
+		)[
 			,
 			paste0(value, collapse = table_description@sep),
 			by = c('entry', 'column')
 		]
+		values[
+			cbind(
+				match(multi_values$entry, entries),
+				match(multi_values$column, cols)
+			)
+		] <- multi_values$V1
 	}
-
-	entries <- sort(unique(d$entry))
-	cols <- sort(unique(d$column))
-	values <- matrix(NA_character_, nrow = length(entries), ncol = length(cols))
-	values[cbind(match(d$entry, entries), match(d$column, cols))] <- d$V1
 	data.table::setnames(data.table::as.data.table(values), cols)
 }
 

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -1,7 +1,7 @@
 ## This file contains all functions needed for flattening ##
 ## Exported functions are on top, internal functions below ##
 
-path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- index <- dummy <- NULL #To stop "no visible binding" NOTE in check()
+path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- id <- index <- dummy <- NULL #To stop "no visible binding" NOTE in check()
 
 
 #' Flatten list of FHIR bundles
@@ -629,8 +629,8 @@ crack_wide_given_columns <- function(bundles, table_description, ncores = 1) {
 						table_description = table_description,
 						use_indices       = TRUE
 					)
-					d[, column := paste0(bra, id, ket, column)]
-					d[, id := NULL]
+					d[, column := paste0(bra, index, ket, column)]
+					d[, index := NULL]
 					cols <- unique(d$column)
 					d <- dcast(d, entry ~ column) # cast columns by bundle and entry
 					data.table::setcolorder(x = d, neworder = cols)
@@ -777,7 +777,7 @@ crack_given_columns_nodes_to_long <- function(nodes, columns, table_description,
 	d
 }
 
-#' Convert a long table as returned by [crack_given_columns_nodes_to_long] to a table
+#' Convert a long table as returned by crack_given_columns_nodes_to_long to a table
 #' with one row per resource
 #' @param d A long data.table with entry, column, value and optional index columns
 #' @param table_description A fhir_table_description

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -615,6 +615,35 @@ crack_given_columns_nodes_to_long <- function(nodes, columns, table_description,
 	d
 }
 
+#' Cast compact given-column values to one row per resource entry
+#' @param d A long data.table with entry, column, value and optional id columns
+#' @param table_description A fhir_table_description
+#' @param use_indices Whether FHIR path indices should be prepended to values
+#' @param bra Opening bracket for indices
+#' @param ket Closing bracket for indices
+#' @noRd
+cast_compact_given_columns <- function(d, table_description, use_indices, bra, ket) {
+	if(use_indices) {
+		d <- d[
+			,
+			paste0(bra, id, ket, value, collapse = table_description@sep),
+			by = c('entry', 'column')
+		]
+	} else {
+		d <- d[
+			,
+			paste0(value, collapse = table_description@sep),
+			by = c('entry', 'column')
+		]
+	}
+
+	entries <- sort(unique(d$entry))
+	cols <- sort(unique(d$column))
+	values <- matrix(NA_character_, nrow = length(entries), ncol = length(cols))
+	values[cbind(match(d$entry, entries), match(d$column, cols))] <- d$V1
+	data.table::setnames(data.table::as.data.table(values), cols)
+}
+
 #' Convert Bundles to a wide table when only some elements should be extracted
 #' @param bundles A fhir_bundle_list
 #' @param table_description A fhir_table_description with a non-empty cols element
@@ -742,11 +771,21 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 							use_indices       = use_indices
 						)
 						if(use_indices) {
-							d[, indexed_value := paste0(bra, id, ket, value)]
-							d <- (d[, paste0(indexed_value, collapse = table_description@sep), by=c('entry', 'column')] |>
-								  	dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
+							d <- cast_compact_given_columns(
+								d                 = d,
+								table_description = table_description,
+								use_indices       = TRUE,
+								bra               = bra,
+								ket               = ket
+							)
 						} else {
-							d <- (d[, paste0(value, collapse = table_description@sep), by=c('entry', 'column')] |> dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
+							d <- cast_compact_given_columns(
+								d                 = d,
+								table_description = table_description,
+								use_indices       = FALSE,
+								bra               = bra,
+								ket               = ket
+							)
 						}
 					}
 				},

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -745,21 +745,29 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 crack_given_columns_nodes_to_long <- function(nodes, columns, table_description, use_indices) {
 	paths <- xml2::xml_path(nodes)
 	values <- xml2::xml_text(nodes)
-	entry_close <- regexpr("]", paths, fixed = TRUE)
+	entry_close <- regexpr("]/resource/", paths, fixed = TRUE)
 	attr_start <- regexpr("/@", paths, fixed = TRUE)
+	has_entry_index <- entry_close != -1L
+	entry <- rep.int(1L, length(paths))
+	entry[has_entry_index] <- as.integer(substr(
+		paths[has_entry_index],
+		nchar("/Bundle/entry[") + 1L,
+		entry_close[has_entry_index] - 1L
+	))
 
 	if(table_description@keep_attr) {
 		columns <- paste0(columns, "@", substring(paths, attr_start + 2L))
 	}
 
 	d <- data.table(
-		entry  = as.integer(substr(paths, nchar("/Bundle/entry[") + 1L, entry_close - 1L)),
+		entry  = entry,
 		column = columns,
 		value  = values
 	)
 
 	if(use_indices) {
-		resource_start <- entry_close + nchar("]/resource/")
+		resource_start <- rep.int(nchar("/Bundle/entry/resource/") + 1L, length(paths))
+		resource_start[has_entry_index] <- entry_close[has_entry_index] + nchar("]/resource/")
 		slash_after_resource <- regexpr("/", substring(paths, resource_start), fixed = TRUE)
 		spath_start <- resource_start + slash_after_resource
 		spath <- substr(paths, spath_start, attr_start - 1L)

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -1,7 +1,7 @@
 ## This file contains all functions needed for flattening ##
 ## Exported functions are on top, internal functions below ##
 
-path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- id <- dummy <- indexed_value <- NULL #To stop "no visible binding" NOTE in check()
+path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- id <- dummy <- NULL #To stop "no visible binding" NOTE in check()
 
 
 #' Flatten list of FHIR bundles

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -1,7 +1,7 @@
 ## This file contains all functions needed for flattening ##
 ## Exported functions are on top, internal functions below ##
 
-path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- id <- dummy <- NULL #To stop "no visible binding" NOTE in check()
+path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- id <- dummy <- indexed_value <- NULL #To stop "no visible binding" NOTE in check()
 
 
 #' Flatten list of FHIR bundles
@@ -601,13 +601,15 @@ crack_given_columns_nodes_to_long <- function(nodes, columns, table_description,
 	)
 
 	if(use_indices) {
+		unique_spath <- unique(spath)
 		indexed_spath <- gsub(
 			pattern = "(^|/)([^/[]+)(?=/|$)",
 			replacement = "\\11",
-			x = spath,
+			x = unique_spath,
 			perl = TRUE
 		)
-		d[, id := gsub("(^\\.)|(\\.$)", "", gsub("[^0-9]+", ".", indexed_spath))]
+		ids <- gsub("(^\\.)|(\\.$)", "", gsub("[^0-9]+", ".", indexed_spath))
+		d[, id := ids[match(spath, unique_spath)]]
 	}
 
 	d
@@ -662,7 +664,7 @@ crack_wide_given_columns <- function(bundles, table_description, ncores = 1) {
 
 				if(0 < length(nodelist)){
 					d <- crack_given_columns_nodes_to_long(
-						nodes             = xml_nodeset(nodelist),
+						nodes             = xml_nodeset(nodelist, deduplicate = FALSE),
 						columns           = rep(names(colwise_list), lengths(colwise_list)),
 						table_description = table_description,
 						use_indices       = TRUE
@@ -734,13 +736,14 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 
 					if(0 < length(nodelist)){
 						d <- crack_given_columns_nodes_to_long(
-							nodes             = xml_nodeset(nodelist),
+							nodes             = xml_nodeset(nodelist, deduplicate = FALSE),
 							columns           = rep(names(colwise_list), lengths(colwise_list)),
 							table_description = table_description,
 							use_indices       = use_indices
 						)
 						if(use_indices) {
-							d <- (d[, paste0(bra, id, ket, value, collapse = table_description@sep), by=c('entry', 'column')] |>
+							d[, indexed_value := paste0(bra, id, ket, value)]
+							d <- (d[, paste0(indexed_value, collapse = table_description@sep), by=c('entry', 'column')] |>
 								  	dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]
 						} else {
 							d <- (d[, paste0(value, collapse = table_description@sep), by=c('entry', 'column')] |> dcast(entry ~ column, value.var = 'V1'))[,-c('entry')]

--- a/R/flatten_resources.R
+++ b/R/flatten_resources.R
@@ -1,7 +1,7 @@
 ## This file contains all functions needed for flattening ##
 ## Exported functions are on top, internal functions below ##
 
-path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- id <- dummy <- NULL #To stop "no visible binding" NOTE in check()
+path <- node <- value <- attrib <- entry <- spath <- xpath <- column <- index <- dummy <- NULL #To stop "no visible binding" NOTE in check()
 
 
 #' Flatten list of FHIR bundles
@@ -574,121 +574,6 @@ crack_compact_all_columns <- function(bundles, table_description, ncores = 1) {
 	)
 }
 
-#' Convert extracted XML attribute nodes into a long table
-#' @param nodes XML attribute nodes extracted from one bundle
-#' @param columns Column names matching the extracted nodes
-#' @param table_description A fhir_table_description
-#' @param use_indices Whether FHIR path indices should be extracted
-#' @noRd
-crack_given_columns_nodes_to_long <- function(nodes, columns, table_description, use_indices) {
-	paths <- xml2::xml_path(nodes)
-	values <- xml2::xml_text(nodes)
-	entry_close <- regexpr("]", paths, fixed = TRUE)
-	attr_start <- regexpr("/@", paths, fixed = TRUE)
-
-	if(table_description@keep_attr) {
-		columns <- paste0(columns, "@", substring(paths, attr_start + 2L))
-	}
-
-	d <- data.table(
-		entry  = as.integer(substr(paths, nchar("/Bundle/entry[") + 1L, entry_close - 1L)),
-		column = columns,
-		value  = values
-	)
-
-	if(use_indices) {
-		resource_start <- entry_close + nchar("]/resource/")
-		slash_after_resource <- regexpr("/", substring(paths, resource_start), fixed = TRUE)
-		spath_start <- resource_start + slash_after_resource
-		spath <- substr(paths, spath_start, attr_start - 1L)
-		unique_spath <- unique(spath)
-		indexed_spath <- gsub(
-			pattern = "(^|/)([^/[]+)(?=/|$)",
-			replacement = "\\11",
-			x = unique_spath,
-			perl = TRUE
-		)
-		ids <- gsub("(^\\.)|(\\.$)", "", gsub("[^0-9]+", ".", indexed_spath))
-		d[, id := ids[match(spath, unique_spath)]]
-	}
-
-	d
-}
-
-#' Cast compact given-column values to one row per resource entry
-#' @param d A long data.table with entry, column, value and optional id columns
-#' @param table_description A fhir_table_description
-#' @param use_indices Whether FHIR path indices should be prepended to values
-#' @param bra Opening bracket for indices
-#' @param ket Closing bracket for indices
-#' @noRd
-cast_compact_given_columns <- function(d, table_description, use_indices, bra, ket) {
-	entries <- sort(unique(d$entry))
-	cols <- sort(unique(d$column))
-	values <- matrix(NA_character_, nrow = length(entries), ncol = length(cols))
-
-	# Dense repeated columns are faster with data.table's grouped collapse.
-	if(nrow(d) / (length(entries) * length(table_description@cols)) > 2) {
-		if(use_indices) {
-			d <- d[
-				,
-				paste0(bra, id, ket, value, collapse = table_description@sep),
-				by = c('entry', 'column')
-			]
-		} else {
-			d <- d[
-				,
-				paste0(value, collapse = table_description@sep),
-				by = c('entry', 'column')
-			]
-		}
-		values[cbind(match(d$entry, entries), match(d$column, cols))] <- d$V1
-		return(data.table::setnames(data.table::as.data.table(values), cols))
-	}
-
-	data.table::setorder(d, entry, column)
-	group_start <- c(TRUE, d$entry[-1L] != d$entry[-nrow(d)] | d$column[-1L] != d$column[-nrow(d)])
-	group_start <- which(group_start)
-	group_end <- c(group_start[-1L] - 1L, nrow(d))
-	group_size <- group_end - group_start + 1L
-	singleton_group <- group_size == 1L
-
-	if(use_indices) {
-		group_values <- paste0(bra, d$id, ket, d$value)
-	} else {
-		group_values <- d$value
-	}
-
-	if(any(singleton_group)) {
-		singleton_start <- group_start[singleton_group]
-		values[
-			cbind(
-				match(d$entry[singleton_start], entries),
-				match(d$column[singleton_start], cols)
-			)
-		] <- group_values[singleton_start]
-	}
-
-	if(any(!singleton_group)) {
-		multi_rows <- rep(!singleton_group, group_size)
-		multi_values <- data.table(
-			entry = d$entry[multi_rows],
-			column = d$column[multi_rows],
-			value = group_values[multi_rows]
-		)[
-			,
-			paste0(value, collapse = table_description@sep),
-			by = c('entry', 'column')
-		]
-		values[
-			cbind(
-				match(multi_values$entry, entries),
-				match(multi_values$column, cols)
-			)
-		] <- multi_values$V1
-	}
-	data.table::setnames(data.table::as.data.table(values), cols)
-}
 
 #' Convert Bundles to a wide table when only some elements should be extracted
 #' @param bundles A fhir_bundle_list
@@ -842,4 +727,128 @@ crack_compact_given_columns <- function(bundles, table_description, ncores = 1) 
 	}
 	if(rm_dummy){result[,grep("^dummy", names(result)):=NULL]}
 	result
+}
+
+#' Convert extracted XML attribute nodes into a long table
+#' @param nodes XML attribute nodes extracted from one bundle
+#' @param columns Column names matching the extracted nodes
+#' @param table_description A fhir_table_description
+#' @param use_indices Whether FHIR path indices should be extracted
+#'
+#' @return A data.table with columns
+#' - entry: representing the entry in the FHIR-Bundle
+#' - column: the column name for the cracked table
+#' - value: the extracted value
+#' - index: FHIR path index for multiple values, only returned if use_indices=TRUE
+#'
+#' @noRd
+crack_given_columns_nodes_to_long <- function(nodes, columns, table_description, use_indices) {
+	paths <- xml2::xml_path(nodes)
+	values <- xml2::xml_text(nodes)
+	entry_close <- regexpr("]", paths, fixed = TRUE)
+	attr_start <- regexpr("/@", paths, fixed = TRUE)
+
+	if(table_description@keep_attr) {
+		columns <- paste0(columns, "@", substring(paths, attr_start + 2L))
+	}
+
+	d <- data.table(
+		entry  = as.integer(substr(paths, nchar("/Bundle/entry[") + 1L, entry_close - 1L)),
+		column = columns,
+		value  = values
+	)
+
+	if(use_indices) {
+		resource_start <- entry_close + nchar("]/resource/")
+		slash_after_resource <- regexpr("/", substring(paths, resource_start), fixed = TRUE)
+		spath_start <- resource_start + slash_after_resource
+		spath <- substr(paths, spath_start, attr_start - 1L)
+		unique_spath <- unique(spath)
+		indexed_spath <- gsub(
+			pattern = "(^|/)([^/[]+)(?=/|$)",
+			replacement = "\\11",
+			x = unique_spath,
+			perl = TRUE
+		)
+		ids <- gsub("(^\\.)|(\\.$)", "", gsub("[^0-9]+", ".", indexed_spath))
+		d[, index := ids[match(spath, unique_spath)]]
+	}
+
+	d
+}
+
+#' Convert a long table as returned by [crack_given_columns_nodes_to_long] to a table
+#' with one row per resource
+#' @param d A long data.table with entry, column, value and optional index columns
+#' @param table_description A fhir_table_description
+#' @param use_indices Whether FHIR path indices should be prepended to values
+#' @param bra Opening bracket for indices
+#' @param ket Closing bracket for indices
+#' @noRd
+cast_compact_given_columns <- function(d, table_description, use_indices, bra, ket) {
+	entries <- sort(unique(d$entry))
+	cols <- sort(unique(d$column))
+	values <- matrix(NA_character_, nrow = length(entries), ncol = length(cols))
+
+	# Dense repeated columns are faster with data.table's grouped collapse.
+	if(nrow(d) / (length(entries) * length(table_description@cols)) > 2) {
+		if(use_indices) {
+			d <- d[
+				,
+				paste0(bra, index, ket, value, collapse = table_description@sep),
+				by = c('entry', 'column')
+			]
+		} else {
+			d <- d[
+				,
+				paste0(value, collapse = table_description@sep),
+				by = c('entry', 'column')
+			]
+		}
+		values[cbind(match(d$entry, entries), match(d$column, cols))] <- d$V1
+		return(data.table::setnames(data.table::as.data.table(values), cols))
+	}
+
+	data.table::setorder(d, entry, column)
+	group_start <- c(TRUE, d$entry[-1L] != d$entry[-nrow(d)] | d$column[-1L] != d$column[-nrow(d)])
+	group_start <- which(group_start)
+	group_end <- c(group_start[-1L] - 1L, nrow(d))
+	group_size <- group_end - group_start + 1L
+	singleton_group <- group_size == 1L
+
+	if(use_indices) {
+		group_values <- paste0(bra, d$index, ket, d$value)
+	} else {
+		group_values <- d$value
+	}
+
+	if(any(singleton_group)) {
+		singleton_start <- group_start[singleton_group]
+		values[
+			cbind(
+				match(d$entry[singleton_start], entries),
+				match(d$column[singleton_start], cols)
+			)
+		] <- group_values[singleton_start]
+	}
+
+	if(any(!singleton_group)) {
+		multi_rows <- rep(!singleton_group, group_size)
+		multi_values <- data.table(
+			entry = d$entry[multi_rows],
+			column = d$column[multi_rows],
+			value = group_values[multi_rows]
+		)[
+			,
+			paste0(value, collapse = table_description@sep),
+			by = c('entry', 'column')
+		]
+		values[
+			cbind(
+				match(multi_values$entry, entries),
+				match(multi_values$column, cols)
+			)
+		] <- multi_values$V1
+	}
+	data.table::setnames(data.table::as.data.table(values), cols)
 }

--- a/man/as_fhir.Rd
+++ b/man/as_fhir.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/download_resources.R
 \name{as_fhir}
 \alias{as_fhir}
-\title{Coerce character vector to \linkS4class{fhir_bundle_list}}
+\title{Coerce character vector to \link[=fhir_bundle_list-class]{fhir_bundle_list}}
 \usage{
 as_fhir(x)
 }
@@ -11,7 +11,7 @@ as_fhir(x)
 }
 \description{
 Tries to convert a character vector containing xml strings representing FHIR bundles to an object of
-class \linkS4class{fhir_bundle_list}.
+class \link[=fhir_bundle_list-class]{fhir_bundle_list}.
 }
 \examples{
 

--- a/man/datasets_real.Rd
+++ b/man/datasets_real.Rd
@@ -43,7 +43,7 @@ patient_bundles
 These data examples can be used to explore some of the functions from the fhircrackr package
 when direct access to a FHIR server is not possible.
 
-All example data sets are \linkS4class{fhir_bundle_list}s containing \linkS4class{fhir_bundle_serialized} objects
+All example data sets are \link[=fhir_bundle_list-class]{fhir_bundle_list}s containing \link[=fhir_bundle_serialized-class]{fhir_bundle_serialized} objects
 representing FHIR bundles as returned by \code{\link[=fhir_search]{fhir_search()}}. They have to be unserialized (once per R session),
 before you can work with them!
 }

--- a/man/fhir_authenticate.Rd
+++ b/man/fhir_authenticate.Rd
@@ -37,7 +37,7 @@ Could hold info about user identity and scope for keycloak like this:
 }\if{html}{\out{</div>}}}
 }
 \description{
-This function is a wrapper to create an \link[httr:Token-class]{httr::Token} object for authentication with OAuth2/OpenID Connect.
+This function is a wrapper to create an \link[httr:Token]{httr::Token} object for authentication with OAuth2/OpenID Connect.
 Internally, it calls \code{\link[httr:oauth_app]{httr::oauth_app()}}, \code{\link[httr:oauth_endpoint]{httr::oauth_endpoint()}} and \code{\link[httr:oauth2.0_token]{httr::oauth2.0_token()}} to create a token that can
 then be used in \link{fhir_search}.
 }

--- a/man/fhir_body-methods.Rd
+++ b/man/fhir_body-methods.Rd
@@ -9,7 +9,7 @@
 \alias{fhir_body,list,character-methods}
 \alias{fhir_body,character,character-method}
 \alias{fhir_body,character,character-methods}
-\title{Create \linkS4class{fhir_body} object}
+\title{Create \link[=fhir_body-class]{fhir_body} object}
 \usage{
 fhir_body(content, type)
 
@@ -28,10 +28,10 @@ and will be concatenated appropriately. In this case the \code{type} will automa
 \item{type}{A string defining the type of the body e.g. \code{"application/x-www-form-urlencoded"} or \code{"xml"}.}
 }
 \value{
-An object of type \linkS4class{fhir_body}.
+An object of type \link[=fhir_body-class]{fhir_body}.
 }
 \description{
-Create \linkS4class{fhir_body} object
+Create \link[=fhir_body-class]{fhir_body} object
 }
 \examples{
 #body that could be used in a FHIR search request POSTed to an URL like baseurl/Patient/_search

--- a/man/fhir_build_bundle-methods.Rd
+++ b/man/fhir_build_bundle-methods.Rd
@@ -32,7 +32,7 @@ the list elements must correspond to the resource type represented in the table!
 
 \item{brackets}{A character vector of length one. The brackets used for cracking.}
 
-\item{resource_type}{A character vector of length one or \linkS4class{fhir_resource_type} object
+\item{resource_type}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object
 indicating which resource type is represented in the table, if a single table is provided. This argument is
 ignored when \code{table} is a named list of tables.}
 
@@ -42,13 +42,13 @@ either \code{"transaction"} (the default) or \code{"batch"}.}
 \item{verbose}{An integer vector of length one. If 0, nothing is printed, if > 0 progress message is printed. Defaults to 1.}
 }
 \value{
-A \linkS4class{fhir_bundle_xml} object.
+A \link[=fhir_bundle_xml-class]{fhir_bundle_xml} object.
 }
 \description{
-This function takes a table as produced by \code{\link[=fhir_crack]{fhir_crack()}} with \code{format="wide"} and builds a \linkS4class{fhir_bundle_xml} object from it. It is primarily used
+This function takes a table as produced by \code{\link[=fhir_crack]{fhir_crack()}} with \code{format="wide"} and builds a \link[=fhir_bundle_xml-class]{fhir_bundle_xml} object from it. It is primarily used
 to create transaction/batch bundles to POST back to a FHIR server. The column names of the table must represent the XPath expression of the
 respective element with indices for repeating items. A table like this is produced when FHIR resources have been cracked with \code{\link[=fhir_crack]{fhir_crack()}} without
-assigning explicit column names in the \linkS4class{fhir_design}/\linkS4class{fhir_table_description} and the format has been set to \code{"wide"}.
+assigning explicit column names in the \link[=fhir_design-class]{fhir_design}/\link[=fhir_table_description-class]{fhir_table_description} and the format has been set to \code{"wide"}.
 }
 \details{
 The typical use case would look like this:

--- a/man/fhir_build_resource.Rd
+++ b/man/fhir_build_resource.Rd
@@ -11,16 +11,16 @@ fhir_build_resource(row, brackets, resource_type)
 
 \item{brackets}{A character vector of length one. The brackets used for cracking.}
 
-\item{resource_type}{A character vector of length one or \linkS4class{fhir_resource_type} object
+\item{resource_type}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object
 indicating which resource type the table is build from.}
 }
 \value{
-A \linkS4class{fhir_resource_xml} object.
+A \link[=fhir_resource_xml-class]{fhir_resource_xml} object.
 }
 \description{
-This function takes a single row from a wide table as produced by \code{\link[=fhir_crack]{fhir_crack()}} and builds a \linkS4class{fhir_resource_xml} object from it. The column names of the table
+This function takes a single row from a wide table as produced by \code{\link[=fhir_crack]{fhir_crack()}} and builds a \link[=fhir_resource_xml-class]{fhir_resource_xml} object from it. The column names of the table
 must represent the XPath expression of the respective element with indices for repeating items. A table like this is produced when FHIR resources have
-been cracked with \code{\link[=fhir_crack]{fhir_crack()}} without assigning explicit column names in the \linkS4class{fhir_design}/\linkS4class{fhir_table_description} and with \code{format} set to \code{"wide"}.
+been cracked with \code{\link[=fhir_crack]{fhir_crack()}} without assigning explicit column names in the \link[=fhir_design-class]{fhir_design}/\link[=fhir_table_description-class]{fhir_table_description} and with \code{format} set to \code{"wide"}.
 }
 \examples{
 #unserialize example

--- a/man/fhir_bundle_list.Rd
+++ b/man/fhir_bundle_list.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fhir_bundle_list.R
 \name{fhir_bundle_list}
 \alias{fhir_bundle_list}
-\title{Create \linkS4class{fhir_bundle_list} object}
+\title{Create \link[=fhir_bundle_list-class]{fhir_bundle_list} object}
 \usage{
 fhir_bundle_list(bundles)
 }
@@ -14,8 +14,8 @@ A fhir_bundle_list is a list of fhir_bundle_xml or fhir_bundle_serialized object
 usually returned by a call to \code{\link[=fhir_search]{fhir_search()}}.
 }
 \details{
-The only scenario where one would use this constructor function is when several \linkS4class{fhir_bundle}
-or \linkS4class{fhir_bundle_list} objects should be merged into one big \linkS4class{fhir_bundle_list} before cracking (see examples).
+The only scenario where one would use this constructor function is when several \link[=fhir_bundle-class]{fhir_bundle}
+or \link[=fhir_bundle_list-class]{fhir_bundle_list} objects should be merged into one big \link[=fhir_bundle_list-class]{fhir_bundle_list} before cracking (see examples).
 }
 \examples{
 

--- a/man/fhir_bundle_xml-class.Rd
+++ b/man/fhir_bundle_xml-class.Rd
@@ -11,8 +11,8 @@ It is usually found inside a \code{fhir_bundle_list} which is returned by a call
 \section{Slots}{
 
 \describe{
-\item{\code{next_link}}{A \linkS4class{fhir_url} pointing to the next bundle on the server.}
+\item{\code{next_link}}{A \link[=fhir_url-class]{fhir_url} pointing to the next bundle on the server.}
 
-\item{\code{self_link}}{A \linkS4class{fhir_url} pointing to this bundle on the server.}
+\item{\code{self_link}}{A \link[=fhir_url-class]{fhir_url} pointing to this bundle on the server.}
 }}
 

--- a/man/fhir_bundle_xml.Rd
+++ b/man/fhir_bundle_xml.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fhir_bundle.R
 \name{fhir_bundle_xml}
 \alias{fhir_bundle_xml}
-\title{Create \linkS4class{fhir_bundle_xml} object}
+\title{Create \link[=fhir_bundle_xml-class]{fhir_bundle_xml} object}
 \usage{
 fhir_bundle_xml(bundle)
 }

--- a/man/fhir_canonical_design.Rd
+++ b/man/fhir_canonical_design.Rd
@@ -7,7 +7,7 @@
 fhir_canonical_design()
 }
 \description{
-Returns the \linkS4class{fhir_design} of the last call to \code{\link[=fhir_crack]{fhir_crack()}}.
+Returns the \link[=fhir_design-class]{fhir_design} of the last call to \code{\link[=fhir_crack]{fhir_crack()}}.
 }
 \examples{
 #load example bundles

--- a/man/fhir_columns-class.Rd
+++ b/man/fhir_columns-class.Rd
@@ -3,10 +3,10 @@
 \docType{class}
 \name{fhir_columns-class}
 \alias{fhir_columns-class}
-\title{A S4 class to represent columns in a \linkS4class{fhir_table_description}}
+\title{A S4 class to represent columns in a \link[=fhir_table_description-class]{fhir_table_description}}
 \description{
-An object of class \code{fhir_columns} is part of a \linkS4class{fhir_table_description}
-in a \linkS4class{fhir_design} and holds information on the elements
+An object of class \code{fhir_columns} is part of a \link[=fhir_table_description-class]{fhir_table_description}
+in a \link[=fhir_design-class]{fhir_design} and holds information on the elements
 that should be extracted from the FHIR resources, as well as the column names of the resulting data.frame.
 The elements to be extracted are indicated by XPath xpaths.
 }

--- a/man/fhir_columns-methods.Rd
+++ b/man/fhir_columns-methods.Rd
@@ -8,7 +8,7 @@
 \alias{fhir_columns,character,character-method}
 \alias{fhir_columns,character,missing-method}
 \alias{fhir_columns,list,missing-method}
-\title{Create \linkS4class{fhir_columns} object}
+\title{Create \link[=fhir_columns-class]{fhir_columns} object}
 \usage{
 fhir_columns(xpaths, colnames)
 
@@ -24,7 +24,7 @@ fhir_columns(xpaths, colnames)
 }
 \arguments{
 \item{xpaths}{A (named) character vector or (named) list containing xpath xpaths,
-or a \linkS4class{fhir_xpath_expression} object.}
+or a \link[=fhir_xpath_expression-class]{fhir_xpath_expression} object.}
 
 \item{colnames}{The names of the columns to create. If no colnames are provided and the list or vector
 in \code{xpaths} has names, those names are taken as the colnames. If no colnames are provided and

--- a/man/fhir_count_resource.Rd
+++ b/man/fhir_count_resource.Rd
@@ -17,7 +17,7 @@ fhir_count_resource(
 \arguments{
 \item{base_url}{A character vector of length one specifying the base URL of the FHIR server, e.g. \code{"http://hapi.fhir.org/baseR4"}.}
 
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
 
 \item{parameters}{Optional. Either a length 1 character vector containing properly formatted FHIR search parameters, e.g.
 \code{"gender=male&_summary=count"} or a named list or named character vector e.g. \code{list(gender="male", "_summary"="count")}

--- a/man/fhir_crack-methods.Rd
+++ b/man/fhir_crack-methods.Rd
@@ -51,7 +51,7 @@ fhir_crack(
 \arguments{
 \item{bundles}{A FHIR search result as returned by \code{\link[=fhir_search]{fhir_search()}}.}
 
-\item{design}{A \linkS4class{fhir_design} or \linkS4class{fhir_table_description} object. See \code{\link[=fhir_design]{fhir_design()}}/\code{\link[=fhir_table_description]{fhir_table_description()}}
+\item{design}{A \link[=fhir_design-class]{fhir_design} or \link[=fhir_table_description-class]{fhir_table_description} object. See \code{\link[=fhir_design]{fhir_design()}}/\code{\link[=fhir_table_description]{fhir_table_description()}}
 and the corresponding vignette (\code{vignette("flattenResources", package ="fhircrackr")}) for a more detailed explanation and
 comprehensive examples of both.}
 
@@ -82,11 +82,11 @@ cpu cores that should be used for parallelised cracking. Parallelisation current
 Defaults to \code{NULL}.}
 }
 \value{
-If a \linkS4class{fhir_design} was used, the result is a list of data.frames, i.e. a \linkS4class{fhir_df_list} object, or a list of data.tables,
-i.e. a \linkS4class{fhir_dt_list} object. If a \linkS4class{fhir_table_description} was used, the result is a single data.frame/data.table.
+If a \link[=fhir_design-class]{fhir_design} was used, the result is a list of data.frames, i.e. a \link[=fhir_df_list-class]{fhir_df_list} object, or a list of data.tables,
+i.e. a \link[=fhir_dt_list-class]{fhir_dt_list} object. If a \link[=fhir_table_description-class]{fhir_table_description} was used, the result is a single data.frame/data.table.
 }
 \description{
-Converts a \linkS4class{fhir_bundle_list} (the result of \code{\link[=fhir_search]{fhir_search()}}) to a data.frame/data.table or list of df/dt,
+Converts a \link[=fhir_bundle_list-class]{fhir_bundle_list} (the result of \code{\link[=fhir_search]{fhir_search()}}) to a data.frame/data.table or list of df/dt,
 if more than one resource type is extracted at once.
 
 There are two main output formats for the table: compact and wide. They differ regarding their handling of multiple occurrences of

--- a/man/fhir_design-class.Rd
+++ b/man/fhir_design-class.Rd
@@ -5,7 +5,7 @@
 \alias{fhir_design-class}
 \title{A S4 class containing a design for \code{\link[=fhir_crack]{fhir_crack()}}}
 \description{
-A fhir_design is a named list of \linkS4class{fhir_table_description} objects. Each table_description
+A fhir_design is a named list of \link[=fhir_table_description-class]{fhir_table_description} objects. Each table_description
 contains information on how to flatten one resource type which will result in one
 data.frame. The fhir_design is passed to the function \code{\link[=fhir_crack]{fhir_crack()}} along with a
 list of bundles containing FHIR resources.

--- a/man/fhir_design-methods.Rd
+++ b/man/fhir_design-methods.Rd
@@ -6,7 +6,7 @@
 \alias{fhir_design,fhir_table_description-method}
 \alias{fhir_design,list-method}
 \alias{fhir_design,fhir_table_list-method}
-\title{Create a \linkS4class{fhir_design} object}
+\title{Create a \link[=fhir_design-class]{fhir_design} object}
 \usage{
 fhir_design(...)
 
@@ -18,7 +18,7 @@ fhir_design(...)
 }
 \arguments{
 \item{...}{One or more \code{fhir_table_description} objects or a named list containing
-\code{fhir_table_description} objects, or an object of class \linkS4class{fhir_df_list}/\linkS4class{fhir_dt_list}.
+\code{fhir_table_description} objects, or an object of class \link[=fhir_df_list-class]{fhir_df_list}/\link[=fhir_dt_list-class]{fhir_dt_list}.
 See \code{\link[=fhir_table_description]{fhir_table_description()}}.}
 }
 \description{
@@ -70,7 +70,7 @@ resource type. See examples.
 For backwards compatibility it is for the moment also possible to build it from an
 old-style design as used in \verb{fhircrackr (< 1.0.0)}. See examples.
 
-If this function is given an object of class \linkS4class{fhir_df_list} or \linkS4class{fhir_dt_list}, it will
+If this function is given an object of class \link[=fhir_df_list-class]{fhir_df_list} or \link[=fhir_dt_list-class]{fhir_dt_list}, it will
 extract the design that was used to create the respective list.
 }
 \examples{

--- a/man/fhir_df_list-class.Rd
+++ b/man/fhir_df_list-class.Rd
@@ -14,6 +14,6 @@ in the slot \code{design}.
 \describe{
 \item{\code{names}}{Character vector containing the names of the data.frames.}
 
-\item{\code{design}}{An object of class \linkS4class{fhir_design} that was used to create the df_list.}
+\item{\code{design}}{An object of class \link[=fhir_design-class]{fhir_design} that was used to create the df_list.}
 }}
 

--- a/man/fhir_dt_list-class.Rd
+++ b/man/fhir_dt_list-class.Rd
@@ -14,6 +14,6 @@ in the slot \code{design}.
 \describe{
 \item{\code{names}}{A character vector containing the names of the data.tables.}
 
-\item{\code{design}}{An object of class \linkS4class{fhir_design} that was used to create the dt_list.}
+\item{\code{design}}{An object of class \link[=fhir_design-class]{fhir_design} that was used to create the dt_list.}
 }}
 

--- a/man/fhir_get_resource_ids.Rd
+++ b/man/fhir_get_resource_ids.Rd
@@ -18,7 +18,7 @@ fhir_get_resource_ids(
 \arguments{
 \item{base_url}{A character vector of length one specifying the base URL of the FHIR server, e.g. \code{"http://hapi.fhir.org/baseR4"}.}
 
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
 
 \item{parameters}{Optional. Either a length 1 character vector containing properly formatted FHIR search parameters, e.g.
 \code{"gender=male&_summary=count"} or a named list or named character vector e.g. \code{list(gender="male", "_summary"="count")}

--- a/man/fhir_get_resources_by_ids.Rd
+++ b/man/fhir_get_resources_by_ids.Rd
@@ -20,7 +20,7 @@ fhir_get_resources_by_ids(
 \arguments{
 \item{base_url}{A character vector of length one specifying the base URL of the FHIR server, e.g. \code{"http://hapi.fhir.org/baseR4"}.}
 
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
 
 \item{ids}{A character vector containing the IDs of the resources that should be downloaded. In the default setting these should be resource (aka logical) IDs.}
 
@@ -45,7 +45,7 @@ for how to create this.}
 \item{verbose}{An integer vector of length 1 containing the level of verbosity. Defaults to 0.}
 }
 \value{
-A \linkS4class{fhir_bundle_list} containing the downloaded resources.
+A \link[=fhir_bundle_list-class]{fhir_bundle_list} containing the downloaded resources.
 }
 \description{
 Downloads FHIR resources represented by a vector of resource IDs.

--- a/man/fhir_is_empty-methods.Rd
+++ b/man/fhir_is_empty-methods.Rd
@@ -20,7 +20,7 @@ fhir_is_empty(bundles)
 \code{TRUE} if the bundle/bundle list is empty, \code{FALSE} if it is not empty.
 }
 \description{
-Checks if a \linkS4class{fhir_bundle_xml} or \linkS4class{fhir_bundle_list} is empty, i.e. does not contain any resources.
+Checks if a \link[=fhir_bundle_xml-class]{fhir_bundle_xml} or \link[=fhir_bundle_list-class]{fhir_bundle_list} is empty, i.e. does not contain any resources.
 }
 \details{
 Empty bundles are returned when a search on a FHIR server does not yield any resources,
@@ -28,9 +28,9 @@ such as when no resources on the server match the specified search criteria. In 
 the server responds with an empty searchset bundle.
 This function checks whether:
 \itemize{
-\item For objects of type \linkS4class{fhir_bundle_xml}, the bundle contains at least one "entry" element
+\item For objects of type \link[=fhir_bundle_xml-class]{fhir_bundle_xml}, the bundle contains at least one "entry" element
 (if not, the bundle is empty and the functions returns \code{TRUE})
-\item For objects of type \linkS4class{fhir_bundle_list}, the first bundle in the list contains at least one "entry" element
+\item For objects of type \link[=fhir_bundle_list-class]{fhir_bundle_list}, the first bundle in the list contains at least one "entry" element
 (if not, the bundle is empty and the functions returns \code{TRUE})
 }
 }

--- a/man/fhir_load.Rd
+++ b/man/fhir_load.Rd
@@ -15,7 +15,7 @@ fhir_load(directory, indices = NULL, pattern = "^[0-9]+\\\\.xml$")
 to be read. Defaults to the regex expression matching file names as produced by \code{\link[=fhir_save]{fhir_save()}}.}
 }
 \value{
-A \linkS4class{fhir_bundle_list}.
+A \link[=fhir_bundle_list-class]{fhir_bundle_list}.
 }
 \description{
 Reads all bundles stored as xml files from a directory.

--- a/man/fhir_load_design.Rd
+++ b/man/fhir_load_design.Rd
@@ -10,10 +10,10 @@ fhir_load_design(file)
 \item{file}{A string specifying the file from which to read.}
 }
 \value{
-A \linkS4class{fhir_design} object. See \code{?fhir_design}.
+A \link[=fhir_design-class]{fhir_design} object. See \code{?fhir_design}.
 }
 \description{
-Loads a \linkS4class{fhir_design} for use with \code{\link[=fhir_crack]{fhir_crack()}} from an xml file into R.
+Loads a \link[=fhir_design-class]{fhir_design} for use with \code{\link[=fhir_crack]{fhir_crack()}} from an xml file into R.
 }
 \examples{
 

--- a/man/fhir_next_bundle_url.Rd
+++ b/man/fhir_next_bundle_url.Rd
@@ -11,8 +11,8 @@ fhir_next_bundle_url(bundle = NULL)
 extract the next link from the last bundle that was downloaded in the most recent call to \code{\link[=fhir_search]{fhir_search()}}.}
 }
 \value{
-A \linkS4class{fhir_url} object referencing next bundle available on the FHIR server.
-Empty \linkS4class{fhir_url} / character vector, if no further bundle is available.
+A \link[=fhir_url-class]{fhir_url} object referencing next bundle available on the FHIR server.
+Empty \link[=fhir_url-class]{fhir_url} / character vector, if no further bundle is available.
 }
 \description{
 fhir_next_bundle_url() gives the link to the next available bundle, either of the bundle

--- a/man/fhir_post-methods.Rd
+++ b/man/fhir_post-methods.Rd
@@ -56,9 +56,9 @@ fhir_post(
 )
 }
 \arguments{
-\item{url}{An object of class \linkS4class{fhir_url} or a character vector of length one containing the url to POST to.}
+\item{url}{An object of class \link[=fhir_url-class]{fhir_url} or a character vector of length one containing the url to POST to.}
 
-\item{body}{An object of class  \linkS4class{fhir_resource}, \linkS4class{fhir_bundle_xml} or \linkS4class{fhir_body}.
+\item{body}{An object of class  \link[=fhir_resource-class]{fhir_resource}, \link[=fhir_bundle_xml-class]{fhir_bundle_xml} or \link[=fhir_body-class]{fhir_body}.
 See details for how to generate them.}
 
 \item{username}{A character vector of length one containing the username for basic authentication.}
@@ -84,10 +84,10 @@ This function is a convenience wrapper around \code{\link[httr:POST]{httr::POST(
 \details{
 \code{\link[=fhir_post]{fhir_post()}} accepts four classes for the body:
 \enumerate{
-\item A \linkS4class{fhir_resource} as created by \code{\link[=fhir_build_resource]{fhir_build_resource()}}. This is used when just a single resource should be POSTed to the server.
+\item A \link[=fhir_resource-class]{fhir_resource} as created by \code{\link[=fhir_build_resource]{fhir_build_resource()}}. This is used when just a single resource should be POSTed to the server.
 In this case \code{url} must contain the base url plus the resource type, e.g. http://hapi.fhir.org/baseR4/Patient.
-\item A \linkS4class{fhir_bundle_xml} representing a transaction or batch bundle as created by \code{\link[=fhir_build_bundle]{fhir_build_bundle()}}.
-\item A \linkS4class{fhir_body} as created by \code{\link[=fhir_body]{fhir_body()}}. This is the most flexible approach, because within the \linkS4class{fhir_body} object you can represent
+\item A \link[=fhir_bundle_xml-class]{fhir_bundle_xml} representing a transaction or batch bundle as created by \code{\link[=fhir_build_bundle]{fhir_build_bundle()}}.
+\item A \link[=fhir_body-class]{fhir_body} as created by \code{\link[=fhir_body]{fhir_body()}}. This is the most flexible approach, because within the \link[=fhir_body-class]{fhir_body} object you can represent
 any kind of \code{content} as a string and set the \code{type} accordingly. See examples.
 }
 

--- a/man/fhir_put.Rd
+++ b/man/fhir_put.Rd
@@ -16,9 +16,9 @@ fhir_put(
 )
 }
 \arguments{
-\item{url}{An object of class \linkS4class{fhir_url} or a character vector of length one containing the url to PUT to.}
+\item{url}{An object of class \link[=fhir_url-class]{fhir_url} or a character vector of length one containing the url to PUT to.}
 
-\item{body}{An object of class \linkS4class{fhir_resource} or \linkS4class{fhir_body}. See details for how to generate them.}
+\item{body}{An object of class \link[=fhir_resource-class]{fhir_resource} or \link[=fhir_body-class]{fhir_body}. See details for how to generate them.}
 
 \item{username}{A character vector of length one containing the username for basic authentication.}
 
@@ -43,10 +43,10 @@ This function is a convenience wrapper around \code{\link[httr:PUT]{httr::PUT()}
 \details{
 \code{\link[=fhir_put]{fhir_put()}} accepts two classes for the body:
 \enumerate{
-\item A \linkS4class{fhir_resource} as created by \code{\link[=fhir_build_resource]{fhir_build_resource()}}. This is used when just a single resource should be PUT to the server.
+\item A \link[=fhir_resource-class]{fhir_resource} as created by \code{\link[=fhir_build_resource]{fhir_build_resource()}}. This is used when just a single resource should be PUT to the server.
 In this case \code{url} must contain the base url plus the resource type and the resource id,
 e.g. http://hapi.fhir.org/baseR4/Patient/1a2b3c.
-\item A \linkS4class{fhir_body} as created by \code{\link[=fhir_body]{fhir_body()}}. This is the most flexible approach, because within the \linkS4class{fhir_body} object you can represent
+\item A \link[=fhir_body-class]{fhir_body} as created by \code{\link[=fhir_body]{fhir_body()}}. This is the most flexible approach, because within the \link[=fhir_body-class]{fhir_body} object you can represent
 any kind of \code{content} as a string and set the \code{type} accordingly. See examples.
 }
 

--- a/man/fhir_resource_type.Rd
+++ b/man/fhir_resource_type.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fhir_resource_type.R
 \name{fhir_resource_type}
 \alias{fhir_resource_type}
-\title{Create \linkS4class{fhir_resource_type} object}
+\title{Create \link[=fhir_resource_type-class]{fhir_resource_type} object}
 \usage{
 fhir_resource_type(string, fix_capitalization = TRUE)
 }
@@ -14,10 +14,10 @@ types listed at https://hl7.org/FHIR/resourcelist.html}
 \code{medicationstatement -> MedicationStatement}. Defaults to TRUE.}
 }
 \value{
-An \linkS4class{fhir_resource_type} object
+An \link[=fhir_resource_type-class]{fhir_resource_type} object
 }
 \description{
-This function creates an object of class \linkS4class{fhir_resource_type}. It checks the resource type against the list
+This function creates an object of class \link[=fhir_resource_type-class]{fhir_resource_type}. It checks the resource type against the list
 of resource types provided at https://hl7.org/FHIR/resourcelist.html, corrects wrong cases (which can be disabled with \code{fix_capitalization = FALSE})
 and throws a warning if the resource cannot be found at hl7.org.
 }

--- a/man/fhir_resource_xml-methods.Rd
+++ b/man/fhir_resource_xml-methods.Rd
@@ -6,7 +6,7 @@
 \alias{fhir_resource_xml,xml_document-method}
 \alias{fhir_resource_xml,xml_node-method}
 \alias{fhir_resource_xml,character-method}
-\title{Create \linkS4class{fhir_resource_xml} object}
+\title{Create \link[=fhir_resource_xml-class]{fhir_resource_xml} object}
 \usage{
 fhir_resource_xml(resource)
 
@@ -20,7 +20,7 @@ fhir_resource_xml(resource)
 \item{resource}{A xml-object representing a FHIR resource}
 }
 \description{
-Create \linkS4class{fhir_resource_xml} object
+Create \link[=fhir_resource_xml-class]{fhir_resource_xml} object
 }
 \examples{
 fhir_resource_xml(resource = xml2::read_xml("<Patient><id value = '1'/></Patient>"))

--- a/man/fhir_rm_div.Rd
+++ b/man/fhir_rm_div.Rd
@@ -7,7 +7,7 @@
 fhir_rm_div(x)
 }
 \arguments{
-\item{x}{A \linkS4class{fhir_bundle_xml} or \linkS4class{fhir_bundle_list} object or a character vector
+\item{x}{A \link[=fhir_bundle_xml-class]{fhir_bundle_xml} or \link[=fhir_bundle_list-class]{fhir_bundle_list} object or a character vector
 containing xml objects.}
 }
 \value{

--- a/man/fhir_rm_tag-methods.Rd
+++ b/man/fhir_rm_tag-methods.Rd
@@ -17,7 +17,7 @@ fhir_rm_tag(x, tag)
 \S4method{fhir_rm_tag}{fhir_bundle_list}(x, tag)
 }
 \arguments{
-\item{x}{A \linkS4class{fhir_bundle_xml} or \linkS4class{fhir_bundle_list} object or a character vector
+\item{x}{A \link[=fhir_bundle_xml-class]{fhir_bundle_xml} or \link[=fhir_bundle_list-class]{fhir_bundle_list} object or a character vector
 containing xml objects.}
 
 \item{tag}{A character vector of length 1 containing the tag that should be removed, e.g. \code{"div"}.}
@@ -26,7 +26,7 @@ containing xml objects.}
 An object of the same class as \code{x} where all tags matching the \code{tag} argument are removed.
 }
 \description{
-Removes a given xml tag from xml objects represented in a \linkS4class{fhir_bundle_xml}, \linkS4class{fhir_bundle_list}
+Removes a given xml tag from xml objects represented in a \link[=fhir_bundle_xml-class]{fhir_bundle_xml}, \link[=fhir_bundle_list-class]{fhir_bundle_list}
 or character vector.
 }
 \details{

--- a/man/fhir_sample_resources.Rd
+++ b/man/fhir_sample_resources.Rd
@@ -20,7 +20,7 @@ fhir_sample_resources(
 \arguments{
 \item{base_url}{A character vector of length one specifying the base URL of the FHIR server, e.g. \code{"http://hapi.fhir.org/baseR4"}.}
 
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object with the resource type to be downloaded, e.g. \code{"Patient"}.}
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object with the resource type to be downloaded, e.g. \code{"Patient"}.}
 
 \item{parameters}{Optional. Either a length 1 character vector containing properly formatted FHIR search parameters, e.g.
 \code{"gender=male&_summary=count"} or a named list or named character vector e.g. \code{list(gender="male", "_summary"="count")}
@@ -43,7 +43,7 @@ for how to create this.}
 \item{verbose}{An integer of length 1 containing the level of verbosity. Defaults to 1.}
 }
 \value{
-A \linkS4class{fhir_bundle_list} containing randomly sampled resources.
+A \link[=fhir_bundle_list-class]{fhir_bundle_list} containing randomly sampled resources.
 }
 \description{
 Downloads a random sample of resources of a given resource type from a FHIR server. The resources can be further constrained

--- a/man/fhir_sample_resources_by_ids.Rd
+++ b/man/fhir_sample_resources_by_ids.Rd
@@ -21,7 +21,7 @@ fhir_sample_resources_by_ids(
 \arguments{
 \item{base_url}{A character vector of length one specifying the base URL of the FHIR server, e.g. \code{"http://hapi.fhir.org/baseR4"}.}
 
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object with the resource type to be downloaded e.g. \code{"Patient"}.}
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object with the resource type to be downloaded e.g. \code{"Patient"}.}
 
 \item{ids}{A character vector containing the IDs from which to sample.}
 

--- a/man/fhir_save_design.Rd
+++ b/man/fhir_save_design.Rd
@@ -7,13 +7,13 @@
 fhir_save_design(design, file = "design.xml")
 }
 \arguments{
-\item{design}{A \linkS4class{fhir_design} object. See \code{\link[=fhir_design]{fhir_design()}}.}
+\item{design}{A \link[=fhir_design-class]{fhir_design} object. See \code{\link[=fhir_design]{fhir_design()}}.}
 
 \item{file}{A string specifying the file to write to, defaults to writing 'design.xml'
 into the current working directory.}
 }
 \description{
-Writes a \linkS4class{fhir_design} for use with \code{\link[=fhir_crack]{fhir_crack()}} to an xml file.
+Writes a \link[=fhir_design-class]{fhir_design} for use with \code{\link[=fhir_crack]{fhir_crack()}} to an xml file.
 }
 \examples{
 #create and save design

--- a/man/fhir_search.Rd
+++ b/man/fhir_search.Rd
@@ -22,7 +22,7 @@ fhir_search(
 )
 }
 \arguments{
-\item{request}{An object of class \linkS4class{fhir_url} or a character vector of length one containing the full FHIR search request. It is
+\item{request}{An object of class \link[=fhir_url-class]{fhir_url} or a character vector of length one containing the full FHIR search request. It is
 recommended to explicitly create the request via \code{\link[=fhir_url]{fhir_url()}} as this will do some validity checks and format the url properly.
 Defaults to \code{\link[=fhir_current_request]{fhir_current_request()}}}
 
@@ -79,7 +79,7 @@ See \code{\link[=fhir_rm_div]{fhir_rm_div()}} and \code{\link[=fhir_rm_tag]{fhir
 }}
 }
 \value{
-A \linkS4class{fhir_bundle_list} when \code{save_to_disc = NULL} (the default),  else \code{NULL}.
+A \link[=fhir_bundle_list-class]{fhir_bundle_list} when \code{save_to_disc = NULL} (the default),  else \code{NULL}.
 }
 \description{
 Downloads all FHIR bundles of a FHIR search request from a FHIR server by iterating through the bundles. Search via GET

--- a/man/fhir_serialize-methods.Rd
+++ b/man/fhir_serialize-methods.Rd
@@ -8,7 +8,7 @@
 \alias{fhir_serialize,fhir_bundle_list-method}
 \alias{fhir_serialize,fhir_resource_xml-method}
 \alias{fhir_serialize,fhir_resource_serialized-method}
-\title{Serialize a \linkS4class{fhir_bundle}, \linkS4class{fhir_bundle_list} or \linkS4class{fhir_resource}}
+\title{Serialize a \link[=fhir_bundle-class]{fhir_bundle}, \link[=fhir_bundle_list-class]{fhir_bundle_list} or \link[=fhir_resource-class]{fhir_resource}}
 \usage{
 fhir_serialize(bundles)
 
@@ -23,14 +23,14 @@ fhir_serialize(bundles)
 \S4method{fhir_serialize}{fhir_resource_serialized}(bundles)
 }
 \arguments{
-\item{bundles}{A \linkS4class{fhir_bundle}, \linkS4class{fhir_bundle_list} or \linkS4class{fhir_resource} object.}
+\item{bundles}{A \link[=fhir_bundle-class]{fhir_bundle}, \link[=fhir_bundle_list-class]{fhir_bundle_list} or \link[=fhir_resource-class]{fhir_resource} object.}
 }
 \value{
-A  \linkS4class{fhir_bundle_xml}, \linkS4class{fhir_bundle_list} or \linkS4class{fhir_resource_xml}  object.
+A  \link[=fhir_bundle_xml-class]{fhir_bundle_xml}, \link[=fhir_bundle_list-class]{fhir_bundle_list} or \link[=fhir_resource_xml-class]{fhir_resource_xml}  object.
 }
 \description{
 Serializes FHIR bundles or resources to allow for saving in .rda or .RData format without losing integrity of pointers
-i.e. it turns a \linkS4class{fhir_bundle_xml}/\linkS4class{fhir_resource_xml} object into an \linkS4class{fhir_bundle_serialized}/\linkS4class{fhir_resource_serialized} object.
+i.e. it turns a \link[=fhir_bundle_xml-class]{fhir_bundle_xml}/\link[=fhir_resource_xml-class]{fhir_resource_xml} object into an \link[=fhir_bundle_serialized-class]{fhir_bundle_serialized}/\link[=fhir_resource_serialized-class]{fhir_resource_serialized} object.
 }
 \examples{
 

--- a/man/fhir_style-class.Rd
+++ b/man/fhir_style-class.Rd
@@ -6,7 +6,7 @@
 \title{An S4 class to represent a design for cracking FHIR resources}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-\linkS4class{fhir_style} is now deprecated, the information that used to be coded here has been moved to the \linkS4class{fhir_table_description}.
+\link[=fhir_style-class]{fhir_style} is now deprecated, the information that used to be coded here has been moved to the \link[=fhir_table_description-class]{fhir_table_description}.
 }
 \section{Slots}{
 

--- a/man/fhir_style.Rd
+++ b/man/fhir_style.Rd
@@ -22,10 +22,10 @@ A fhir_style object
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 This function was used to create an object of class \code{fhir_style} in fhircrackr < 2.0.0.
-It is now deprecated, the information that used to be coded in \code{fhir_style} has been moved to the \linkS4class{fhir_table_description}.
+It is now deprecated, the information that used to be coded in \code{fhir_style} has been moved to the \link[=fhir_table_description-class]{fhir_table_description}.
 }
 \details{
-A \code{fhir_style} object is part of a \linkS4class{fhir_table_description} which in turn is part of a \linkS4class{fhir_design} and
+A \code{fhir_style} object is part of a \link[=fhir_table_description-class]{fhir_table_description} which in turn is part of a \link[=fhir_design-class]{fhir_design} and
 ultimately used in \code{\link[=fhir_crack]{fhir_crack()}}. A \code{fhir_style} object contains three elements:
 \itemize{
 \item \code{sep}: A string defining the separator used to separate multiple entries for the same element in a FHIR resource,

--- a/man/fhir_table_description-class.Rd
+++ b/man/fhir_table_description-class.Rd
@@ -51,11 +51,11 @@ keep_attr:     FALSE
 \section{Slots}{
 
 \describe{
-\item{\code{resource}}{An object of class \linkS4class{fhir_resource_type} defining the resource type that
+\item{\code{resource}}{An object of class \link[=fhir_resource_type-class]{fhir_resource_type} defining the resource type that
 should be extracted.}
 
-\item{\code{cols}}{An object of class \linkS4class{fhir_columns} describing which columns should be created and how.
-If this is an empty \linkS4class{fhir_columns} object, the call to \code{\link[=fhir_crack]{fhir_crack()}} will extract all available
+\item{\code{cols}}{An object of class \link[=fhir_columns-class]{fhir_columns} describing which columns should be created and how.
+If this is an empty \link[=fhir_columns-class]{fhir_columns} object, the call to \code{\link[=fhir_crack]{fhir_crack()}} will extract all available
 elements and put them in automatically named columns.}
 
 \item{\code{sep}}{A character of length one containing the separator string used for separating multiple entries in cells when \code{format = "compact"}.

--- a/man/fhir_table_description.Rd
+++ b/man/fhir_table_description.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fhir_table_description.R
 \name{fhir_table_description}
 \alias{fhir_table_description}
-\title{Create \linkS4class{fhir_table_description} object}
+\title{Create \link[=fhir_table_description-class]{fhir_table_description} object}
 \usage{
 fhir_table_description(
   resource,
@@ -16,13 +16,13 @@ fhir_table_description(
 )
 }
 \arguments{
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object
 indicating which resource type should be extracted.}
 
-\item{cols}{Optional. A \linkS4class{fhir_columns} object or something that can be coerced to one,
+\item{cols}{Optional. A \link[=fhir_columns-class]{fhir_columns} object or something that can be coerced to one,
 like a (named) character vector, a (named) list containing xpath expressions,
-or a \linkS4class{fhir_xpath_expression} object. See \code{\link[=fhir_columns]{fhir_columns()}} and the examples.
-If this argument is omitted, an empty \linkS4class{fhir_columns} object will be supplied.
+or a \link[=fhir_xpath_expression-class]{fhir_xpath_expression} object. See \code{\link[=fhir_columns]{fhir_columns()}} and the examples.
+If this argument is omitted, an empty \link[=fhir_columns-class]{fhir_columns} object will be supplied.
 This means that in the call to \code{\link[=fhir_crack]{fhir_crack()}}, all available elements are extracted in put
 in automatically named columns.}
 
@@ -45,7 +45,7 @@ should be attached to the name of the variable in the resulting table. Defaults 
 \item{style}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}}
 }
 \value{
-An object of class \linkS4class{fhir_table_description}.
+An object of class \link[=fhir_table_description-class]{fhir_table_description}.
 }
 \description{
 A \code{fhir_table_description} holds the information \code{\link[=fhir_crack]{fhir_crack()}} needs to flatten (aka crack)

--- a/man/fhir_tree.Rd
+++ b/man/fhir_tree.Rd
@@ -20,7 +20,7 @@ fhir_tree(
 
 \item{brackets}{A character vector of length two. The brackets used in the table.}
 
-\item{resource}{A character vector of length one or \linkS4class{fhir_resource_type} object indicating which resource type the table is build from.}
+\item{resource}{A character vector of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object indicating which resource type the table is build from.}
 
 \item{keep_attr}{A logical vector of length one indicating whether attributes should be displayed or not.
 Only used for formats \code{"plain"} and \code{"fancy"}.}

--- a/man/fhir_unserialize-methods.Rd
+++ b/man/fhir_unserialize-methods.Rd
@@ -8,7 +8,7 @@
 \alias{fhir_unserialize,fhir_resource_xml-method}
 \alias{fhir_unserialize,fhir_resource_serialized-method}
 \alias{fhir_unserialize,fhir_bundle_list-method}
-\title{Unserialize a \linkS4class{fhir_bundle}, \linkS4class{fhir_bundle_list} or \linkS4class{fhir_resource}}
+\title{Unserialize a \link[=fhir_bundle-class]{fhir_bundle}, \link[=fhir_bundle_list-class]{fhir_bundle_list} or \link[=fhir_resource-class]{fhir_resource}}
 \usage{
 fhir_unserialize(bundles)
 
@@ -23,14 +23,14 @@ fhir_unserialize(bundles)
 \S4method{fhir_unserialize}{fhir_bundle_list}(bundles)
 }
 \arguments{
-\item{bundles}{A \linkS4class{fhir_bundle}, \linkS4class{fhir_bundle_list} or \linkS4class{fhir_resource} object.}
+\item{bundles}{A \link[=fhir_bundle-class]{fhir_bundle}, \link[=fhir_bundle_list-class]{fhir_bundle_list} or \link[=fhir_resource-class]{fhir_resource} object.}
 }
 \value{
-A  \linkS4class{fhir_bundle_serialized}, \linkS4class{fhir_bundle_list} or \linkS4class{fhir_resource_serialized}object.
+A  \link[=fhir_bundle_serialized-class]{fhir_bundle_serialized}, \link[=fhir_bundle_list-class]{fhir_bundle_list} or \link[=fhir_resource_serialized-class]{fhir_resource_serialized}object.
 }
 \description{
 Unserializes FHIR resources or bundles that have been serialized to allow for saving in .rda or .RData format,
-i.e. it turns a \linkS4class{fhir_bundle_serialized}/\linkS4class{fhir_resource_serialized} object into an \linkS4class{fhir_bundle_xml}/\linkS4class{fhir_resource_xml} object.
+i.e. it turns a \link[=fhir_bundle_serialized-class]{fhir_bundle_serialized}/\link[=fhir_resource_serialized-class]{fhir_resource_serialized} object into an \link[=fhir_bundle_xml-class]{fhir_bundle_xml}/\link[=fhir_resource_xml-class]{fhir_resource_xml} object.
 }
 \examples{
 

--- a/man/fhir_url-methods.Rd
+++ b/man/fhir_url-methods.Rd
@@ -24,7 +24,7 @@ fhir_url(url, resource, parameters, url_enc = TRUE)
 e.g. \code{"http://hapi.fhir.org/baseR4/Patient?gender=male&_summary=count"}, or
 the base URL to the FHIR server, e.g. \code{"http://hapi.fhir.org/baseR4"}.}
 
-\item{resource}{A character of length one or \linkS4class{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
+\item{resource}{A character of length one or \link[=fhir_resource_type-class]{fhir_resource_type} object with the resource type to be searched, e.g. \code{"Patient"}.}
 
 \item{parameters}{Optional. Either a length 1 character containing properly formatted FHIR search parameters, e.g.
 \code{"gender=male&_summary=count"} or a named list or named character vector e.g. \code{list(gender="male", "_summary"="count")}
@@ -33,10 +33,10 @@ or \code{c(gender="male", "_summary"="count")}. Note that parameter names beginn
 \item{url_enc}{Should the url be URL-encoded? Defaults to \code{TRUE}.}
 }
 \value{
-An object of class \linkS4class{fhir_url}
+An object of class \link[=fhir_url-class]{fhir_url}
 }
 \description{
-This function creates an object of class \linkS4class{fhir_url} which mostly represents a URL-encoded URL for
+This function creates an object of class \link[=fhir_url-class]{fhir_url} which mostly represents a URL-encoded URL for
 a FHIR search request. A valid Search URL contains a base URL and a resource type and may contain additional
 search parameters. For more info on FHIR search see https://www.hl7.org/fhir/search.html.
 }

--- a/tests/testthat/test_fhir_crack.R
+++ b/tests/testthat/test_fhir_crack.R
@@ -196,6 +196,58 @@ testthat::test_that(
 )
 
 testthat::test_that(
+	"fhir_crack given columns handles bundles with a single unindexed entry", {
+		bundle <- xml2::read_xml(
+			"<Bundle>
+				<type value='searchset'/>
+				<entry>
+					<resource>
+						<Patient>
+							<id value='id1'/>
+							<gender value='female'/>
+							<address>
+								<city value='Amsterdam'/>
+							</address>
+							<address>
+								<city value='Rome'/>
+							</address>
+						</Patient>
+					</resource>
+				</entry>
+			</Bundle>"
+		)
+		bundle_list <- fhir_bundle_list(list(fhir_bundle_xml(bundle)))
+		cols <- c(id = "id", gender = "gender", city = "address/city")
+
+		compact <- fhir_crack(
+			bundles = bundle_list,
+			design = fhir_table_description("Patient", cols = cols),
+			verbose = 0,
+			data.table = TRUE
+		)
+		testthat::expect_equal(compact$id, "id1")
+		testthat::expect_equal(compact$gender, "female")
+		testthat::expect_equal(compact$city, "Amsterdam:::Rome")
+
+		wide <- fhir_crack(
+			bundles = bundle_list,
+			design = fhir_table_description(
+				"Patient",
+				cols = cols,
+				format = "wide",
+				brackets = c("[", "]")
+			),
+			verbose = 0,
+			data.table = TRUE
+		)
+		testthat::expect_equal(wide$`[1]id`, "id1")
+		testthat::expect_equal(wide$`[1]gender`, "female")
+		testthat::expect_equal(wide$`[1.1]city`, "Amsterdam")
+		testthat::expect_equal(wide$`[2.1]city`, "Rome")
+	}
+)
+
+testthat::test_that(
 	"fhir_crack preserves nodes selected by overlapping columns", {
 		bundles <- fhir_unserialize(example_bundles3)
 		cols <- c(

--- a/tests/testthat/test_fhir_crack.R
+++ b/tests/testthat/test_fhir_crack.R
@@ -196,6 +196,47 @@ testthat::test_that(
 )
 
 testthat::test_that(
+	"fhir_crack preserves nodes selected by overlapping columns", {
+		bundles <- fhir_unserialize(example_bundles3)
+		cols <- c(
+			any_city = "address/city",
+			home_city = "address[use[@value='home']]/city"
+		)
+
+		compact <- fhir_crack(
+			bundles = bundles,
+			design = fhir_table_description(resource = "Patient", cols = cols),
+			verbose = 0,
+			data.table = TRUE
+		)
+		testthat::expect_equal(
+			compact$home_city,
+			c("Amsterdam", "Rome", "Berlin")
+		)
+		testthat::expect_equal(
+			compact$any_city,
+			c("Amsterdam", "Rome:::Stockholm", "Berlin:::London")
+		)
+
+		wide <- fhir_crack(
+			bundles = bundles,
+			design = fhir_table_description(
+				resource = "Patient",
+				cols = cols,
+				format = "wide",
+				brackets = c("[", "]")
+			),
+			verbose = 0,
+			data.table = TRUE
+		)
+		testthat::expect_equal(wide$`[1.1]home_city`, c("Amsterdam", "Rome", "Berlin"))
+		testthat::expect_equal(wide$`[1.1]any_city`, c("Amsterdam", "Rome", "Berlin"))
+		testthat::expect_equal(wide$`[2.1]any_city`, c(NA, "Stockholm", NA))
+		testthat::expect_equal(wide$`[3.1]any_city`, c(NA, NA, "London"))
+	}
+)
+
+testthat::test_that(
 	"fhir_crack wide given columns produces correct output",{
 		expect_snapshot_value({
 			bundles <- fhir_unserialize(example_bundles3)

--- a/tests/testthat/test_fhir_crack.R
+++ b/tests/testthat/test_fhir_crack.R
@@ -237,6 +237,30 @@ testthat::test_that(
 )
 
 testthat::test_that(
+	"fhir_crack compact given columns deduplicates repeated resource ids", {
+		bundles <- fhir_unserialize(example_bundles3)
+		duplicated_bundles <- fhir_bundle_list(c(bundles, bundles))
+
+		compact <- fhir_crack(
+			bundles = duplicated_bundles,
+			design = fhir_table_description(
+				resource = "Patient",
+				cols = c(id = "id", city = "address/city")
+			),
+			verbose = 0,
+			data.table = TRUE
+		)
+
+		testthat::expect_equal(nrow(compact), 3L)
+		testthat::expect_equal(compact$id, c("id1", "id2", "id3"))
+		testthat::expect_equal(
+			compact$city,
+			c("Amsterdam", "Rome:::Stockholm", "Berlin:::London")
+		)
+	}
+)
+
+testthat::test_that(
 	"fhir_crack wide given columns produces correct output",{
 		expect_snapshot_value({
 			bundles <- fhir_unserialize(example_bundles3)


### PR DESCRIPTION
## Summary

This PR optimizes `fhir_crack()` for the given-column extraction path used by compact designs. It reduces repeated XPath/path handling, replaces the compact given-column cast with a direct matrix fill, adds a singleton-heavy fast path, avoids redundant compact deduplication when resource IDs are unique, and skips unused path-index parsing when indices are not requested.

It also preserves duplicate node selections for overlapping XPath columns by using `xml_nodeset(..., deduplicate = FALSE)`, which addresses the class of overlap issues discussed in #157.

## Benchmark

Benchmarks use cached FHIR bundles, `count = 1000`, `ncores = 1`, and 5 runs per resource. The clean fhircrackr-only comparison keeps `xml2` on CRAN and compares CRAN `fhircrackr` 2.4.0 against this branch.

| Resource | CRAN fhircrackr | This branch | Speedup |
|---|---:|---:|---:|
| Consent | 71.250s | 20.085s | 3.55x |
| Encounter | 40.367s | 7.245s | 5.57x |
| Condition | 18.194s | 3.098s | 5.87x |
| Observation | 15.157s | 2.655s | 5.71x |
| Patient | 13.882s | 1.772s | 7.83x |

A separate 2x2 matrix was also measured with an optimized local `xml2`; that is intentionally not required for this PR. With optimized `xml2`, the fhircrackr-side speedup ranges from 8.68x to 15.81x because the remaining bottleneck shifts toward xml2 path/search work.

## Validation

- `Rscript -e "Sys.setenv(NOT_CRAN='true'); pkgload::load_all('.', quiet=TRUE); testthat::test_file('tests/testthat/test_fhir_crack.R')"`
  - 26 passes, 0 failures
- `R CMD INSTALL /Users/axs/Projekte/fhircrackr`
  - successful
- Legacy/optimized cracked-output comparison for Consent, Encounter, Condition, Observation, Patient with `count = 1000`
  - `same_names`, `same_dim`, `same_classes`, and `same_values` are all `TRUE` for all five resources
